### PR TITLE
Auth failfast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "jsonrpc"
-version = "0.12.0"
-authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+name = "jsonrpc-async"
+version = "2.0.0"
+authors = ["Jeremy Rubin <j@rubin.io>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
-homepage = "https://github.com/apoelstra/rust-jsonrpc/"
-repository = "https://github.com/apoelstra/rust-jsonrpc/"
-documentation = "https://docs.rs/jsonrpc/"
+homepage = "https://github.com/jeremyrubin/rust-jsonrpc-async/"
+repository = "https://github.com/jeremyrubin/rust-jsonrpc-async/"
+documentation = "https://docs.rs/jsonrpc-async/"
 description = "Rust support for the JSON-RPC 2.0 protocol"
-keywords = [ "protocol", "json", "http", "jsonrpc" ]
+keywords = [ "protocol", "json", "http", "jsonrpc", "asynchronous" ]
 readme	 = "README.md"
 edition="2018"
 

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -103,6 +103,11 @@ impl SimpleHttpTransport {
         // Skip response header fields
         while get_line(&mut reader, request_deadline).await? != "\r\n" {}
 
+        if response_code == 401 {
+            // There is no body in a 401 response, so don't try to read it
+            return Err(Error::HttpErrorCode(response_code));
+        }
+
         // Even if it's != 200, we parse the response as we may get a JSONRPC error instead
         // of the less meaningful HTTP error code.
         let resp_body = get_line(&mut reader, request_deadline).await?;


### PR DESCRIPTION
Don't try to read a body on a 401 response since `bitcoind` doesn't send one.  Attempting to read a body results in an uninformative timeout error.

~~Also updates creat name to match what was actually released.~~
